### PR TITLE
Rewrite using prepend instead of alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ caches_method :name_of_the_method
 caches_method :name_of_the_method, expires_in: 1.day #defalut expires_in is 1 day
 caches_method :name_of_the_method, include_locale: true #default include_locale is false
 ```
+### Notice
+Need to use two separate define functions for instance and class methods (singeton methods)
+
+```
+caches_method :a_defined_method
+caches_class_method :a_defined_class_method
+```
+## Generate methods
+`caches_method :method_name` or `caches_class_method :method_name` will only generate cached method with same name `method_name` for caching and `delete_method_name_cache` for clearing cache.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,19 @@ caches_method :name_of_the_method, include_locale: true #default include_locale 
 Need to use two separate define functions for instance and class methods (singeton methods)
 
 ```
-caches_method :a_defined_method
-caches_class_method :a_defined_class_method
+class Test
+    caches_method :a_defined_method
+    caches_class_method :a_defined_class_method
+    
+    def a_defined_method
+      #
+    end
+    
+    def self.a_defined_class_method
+      #
+    end
+end
+
 ```
 ## Generate methods
 `caches_method :method_name` or `caches_class_method :method_name` will only generate cached method with same name `method_name` for caching and `delete_method_name_cache` for clearing cache.

--- a/lib/cacheable/active_record_extensions.rb
+++ b/lib/cacheable/active_record_extensions.rb
@@ -2,13 +2,15 @@ module Cacheable
   module ActiveRecordExtensions
     extend ActiveSupport::Concern
     included do
-      class << self
-        def inherited_with_cache_extensions(kls)
-          inherited_without_cache_extensions kls
+      module IncludeInheritedCacheable
+        def inherited(kls)
+          super(kls)
           kls.send(:include, Cacheable)
         end
-        alias_method_chain :inherited, :cache_extensions
       end
+
+      singleton_class.prepend IncludeInheritedCacheable
+
       # Existing subclasses pick up the model extension as well
       self.descendants.each do |kls|
         kls.send(:include, Cacheable)

--- a/lib/cacheable/cacheable.rb
+++ b/lib/cacheable/cacheable.rb
@@ -26,11 +26,9 @@ module Cacheable
   end
 
   def self.cache_key(klass, method, *args)
-    include_locale = args.last.is_a?(Hash) && args.last.include?(:include_locale) ?
-                        args.pop.delete(:include_locale) :
-                        false
+    options = args.pop
     key_parts = [class_signature(klass), method, args]
-    key_parts << I18n.locale if include_locale
+    key_parts << I18n.locale if options.is_a?(Hash) && options[:include_locale] == true
     key_parts.join(':')
   end
 

--- a/lib/cacheable/cacheable.rb
+++ b/lib/cacheable/cacheable.rb
@@ -92,8 +92,7 @@ module Cacheable
             Rails.cache.delete(key)
           end
 
-                         private
-
+          private
           def generate_request_store(key, options)
             if options && options[:memoized] == true
               RequestStore.store[key.to_sym] ||= yield

--- a/lib/cacheable/cacheable.rb
+++ b/lib/cacheable/cacheable.rb
@@ -42,88 +42,67 @@ module Cacheable
     class_eval do
       def self.caches_method(*names)
         opts = names.extract_options!
-        @cached_methods ||= []
-        @cached_methods |= names
-
-        @options ||= {}
+        @cache_options ||= {}
         names.each do |name|
-          @options[name] = opts
-          # if instance_methods.include? name.to_sym
-          #   add_method_with_cache name
-          # elsif methods.include? name.to_sym
-          #   add_singleton_method_with_cache name
-          # else
-          #   @cached_methods |= [name]
-          # end
+          @cache_options[name] = opts
+          add_method_with_cache name
         end
       end
 
-      def self.caches_extended_method(*names)
+      def self.caches_class_method(*names)
         opts = names.extract_options!
-        @options ||= {}
+        @cache_options ||= {}
         names.each do |name|
-          @options[name] = opts
-          add_singleton_method_with_cache name
+          @cache_options[name] = opts
+          add_class_method_with_cache name
         end
-      end
-
-      def self.cacheable?(name)
-        @cached_methods.present? && @cached_methods.delete(name).present?
-      end
-
-      def self.method_added(name)
-        super
-        add_method_with_cache name if cacheable? name
-      end
-
-      def self.singleton_method_added(name)
-        super
-        add_singleton_method_with_cache name if cacheable? name
       end
 
       private
 
       def self.add_method_with_cache(name)
-
-            p "ADDD add_method_with_cache #{name}"
-        class_eval(generate_method_with_cache(name), __FILE__, __LINE__ + 1)
-        alias_method_chain name, :cache
+        prepend cache_module_for(name)
       end
 
-      def self.add_singleton_method_with_cache(name)
-            p "ADDD add_singleton_method_with_cache #{name}"
-        generated_method = generate_method_with_cache(name)
-        singleton_class.instance_eval do
-          class_eval(generated_method, __FILE__, __LINE__ + 1)
-          alias_method_chain name, :cache
-        end
+      def self.add_class_method_with_cache(name)
+        singleton_class.prepend cache_module_for(name)
       end
 
-      def self.generate_method_with_cache(target)
-        options = @options[target]
+      def self.cache_module_for(target)
+        options = @cache_options[target]
         duration = options.delete(:expires_in)
         duration ||= Cacheable.default_cache_duration
         name = target.to_s.sub(/([?!=])$/, '')
         punctuation = Regexp.last_match(1)
 
-        <<-EVAL
-        def #{name}_with_cache#{punctuation}(*args)
-          key = Cacheable.cache_key(self, '#{name}', *args#{", #{options}" unless options.empty?})
-          #{generate_request_store(target)} Rails.cache.fetch(key, expires_in: #{duration}) do
-            #{name}_without_cache#{punctuation}(*args)
+        cache_module = Module.new do
+          define_method(target) do |*args|
+            key = Cacheable.cache_key(self, target, *args, options)
+            generate_request_store(key, options) do
+              Rails.cache.fetch(key, expires_in: duration) do
+                super(*args)
+              end
+            end
+          end
+
+          define_method("delete_#{name}_cache#{punctuation}") do |*args|
+            key = Cacheable.cache_key(self, target, *args, options)
+            RequestStore.store[key.to_sym] = nil
+            Rails.cache.delete(key)
+          end
+
+                         private
+
+          def generate_request_store(key, options)
+            if options && options[:memoized] == true
+              RequestStore.store[key.to_sym] ||= yield
+            else
+              yield
+            end
           end
         end
 
-        def delete_#{name}_cache#{punctuation}(*args)
-          key = Cacheable.cache_key(self, '#{name}', *args#{", #{options}" unless options.empty?})
-          RequestStore.store[key.to_sym] = nil
-          Rails.cache.delete(key)
-        end
-        EVAL
-      end
-
-      def self.generate_request_store(target)
-        'RequestStore.store[key.to_sym] ||=' if @options[target][:memoized] == true
+        const_set("#{name}_cache".camelize, cache_module)
       end
     end
   end

--- a/lib/cacheable/cacheable.rb
+++ b/lib/cacheable/cacheable.rb
@@ -72,6 +72,9 @@ module Cacheable
         duration ||= Cacheable.default_cache_duration
         name = target.to_s.sub(/([?!=])$/, '')
         punctuation = Regexp.last_match(1)
+        cache_module_name = "#{name}_cache".camelize
+
+        return const_get(cache_module_name) if const_defined? cache_module_name
 
         cache_module = Module.new do
           define_method(target) do |*args|
@@ -100,7 +103,7 @@ module Cacheable
           end
         end
 
-        const_set("#{name}_cache".camelize, cache_module)
+        const_set(cache_module_name, cache_module)
       end
     end
   end

--- a/spec/active_record_extensions_spec.rb
+++ b/spec/active_record_extensions_spec.rb
@@ -23,8 +23,8 @@ module Cacheable
       class InheritSecond < FakeBase
         caches_method :hello, :world
       end
-      expect(InheritFirst.instance_eval { @cached_methods }).to eq([:something])
-      expect(InheritSecond.instance_eval { @cached_methods }).to eq([:hello, :world])
+      expect(InheritFirst.instance_eval { @cache_options }).to include(:something)
+      expect(InheritSecond.instance_eval { @cache_options }).to include(:hello, :world)
     end
   end
 end

--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -202,14 +202,6 @@ RSpec.describe Cacheable do
         expect(instance_1.method_1).to eq(1)
       end
 
-      it 'returns correct value when calling *_with_cache method' do
-        expect(instance_1.method_1_with_cache).to eq(1)
-      end
-
-      it 'returns correct value when calling *_without_cache method' do
-        expect(instance_1.method_1_without_cache).to eq(1)
-      end
-
       it 'handles method names with punctuation marks' do
         expect(instance_1.contains?).to eq(123)
       end
@@ -289,17 +281,7 @@ RSpec.describe Cacheable do
       let(:instance_2) { CacheableClass2.new }
 
       it 'returns correct value when called directly' do
-        expect(CacheableClass2.a_class_method(1,2)).to eq('1-2-1-2-3')
-      end
-
-      it 'returns correct value when calliing *_without_cache method' do
-        expect(CacheableClass2.a_class_method_without_cache(1,2)).to eq(
-          '1-2-1-2-3')
-      end
-
-      it 'returns correct value when calling *_with_cache method' do
-        expect(CacheableClass2.a_class_method_with_cache(1,2)).to eq(
-          '1-2-1-2-3')
+        expect(CacheableClass2.a_class_method(1, 2)).to eq('1-2-1-2-3')
       end
 
       it 'will cache the class method if there is an instance method with same name' do

--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -1,22 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Cacheable do
-
   let(:cache_duration) { Cacheable.default_cache_duration }
 
   describe '.cache_key' do
     it 'returns the expected cache key' do
-      key = Cacheable.cache_key(Object, 'send', 1, 2, 3)
+      key = Cacheable.cache_key(Object, 'send', 1, 2, 3, {})
       expect(key).to eq("#{Cacheable::CacheVersion.get}:#{Object.name}:send:1:2:3")
     end
 
     it 'returns the expected cache key with hash' do
-      key = Cacheable.cache_key(Object, 'send', 1, 2, 3, {a: 1})
+      key = Cacheable.cache_key(Object, 'send', 1, 2, 3, { a: 1 }, {})
       expect(key).to eq("#{Cacheable::CacheVersion.get}:#{Object.name}:send:1:2:3:{:a=>1}")
     end
 
     it 'returns the expected cache key with locale' do
-      key = Cacheable.cache_key(Object, 'send', 1, 2, 3, { include_locale: true })
+      key = Cacheable.cache_key(Object, 'send', 1, 2, 3, include_locale: true)
       expect(key).to eq("#{Cacheable::CacheVersion.get}:#{Object.name}:send:1:2:3:en")
     end
   end
@@ -24,14 +23,16 @@ RSpec.describe Cacheable do
   describe '.expire' do
     it 'expires the expected key' do
       expect(Rails.cache).to receive(:delete).with(
-        "#{Cacheable::CacheVersion.get}:#{Object.name}:send:1:2:3")
-      Cacheable.expire(Object, 'send', 1, 2, 3)
+        "#{Cacheable::CacheVersion.get}:#{Object.name}:send:1:2:3"
+      )
+      Cacheable.expire(Object, 'send', 1, 2, 3, {})
     end
 
     it 'expires the expected key with locale' do
       expect(Rails.cache).to receive(:delete).with(
-        "#{Cacheable::CacheVersion.get}:#{Object.name}:send:1:2:3:en")
-      Cacheable.expire(Object, 'send', 1, 2, 3, { include_locale: true })
+        "#{Cacheable::CacheVersion.get}:#{Object.name}:send:1:2:3:en"
+      )
+      Cacheable.expire(Object, 'send', 1, 2, 3, include_locale: true)
     end
   end
 

--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -241,8 +241,22 @@ RSpec.describe Cacheable do
         end
         expect(Rails.cache).to receive(:fetch).with(
           "#{Cacheable::CacheVersion.get}:#{instance_1.class.name}:#{instance_1.id}:more_arguments:0:1",
-          expires_in: cache_duration)
+          expires_in: cache_duration
+        )
         instance_1.more_arguments(0, 1)
+      end
+
+      context 'with method is defined from included module' do
+        it 'returns correct value' do
+          expect(instance_1.a_defined_module_method(2)).to eq(2)
+        end
+
+        it 'calls Rails.cache with the expected arguments' do
+          expect(Rails.cache).to receive(:fetch).with(
+            "#{Cacheable::CacheVersion.get}:#{instance_1.class.name}:#{instance_1.object_id}:a_defined_module_method:2", expires_in: cache_duration
+          )
+          instance_1.a_defined_module_method(2)
+        end
       end
 
       describe 'arguments' do
@@ -311,14 +325,30 @@ RSpec.describe Cacheable do
         CacheableClass2.with_expiry
       end
 
-      it 'added method_with_cache even if method is defined before from extend module' do
-        expect(CacheableClass1.a_defined_module_class_method).to eq(2)
-        expect(CacheableClass1.a_defined_module_class_method_with_cache).to eq(2)
+      context 'with method is defined from extend module' do
+        it 'returns correct value' do
+          expect(CacheableClass1.a_defined_module_class_method(2)).to eq(2)
+        end
+
+        it 'calls Rails.cache with the expected arguments' do
+          expect(Rails.cache).to receive(:fetch).with(
+            "#{Cacheable::CacheVersion.get}:#{CacheableClass1.name}:a_defined_module_class_method:2", expires_in: cache_duration
+          )
+          CacheableClass1.a_defined_module_class_method(2)
+        end
       end
 
-      it 'added method_with_cache even if method is defined before from super class' do
-        expect(CacheableClass1.a_defined_super_class_method).to eq(3)
-        expect(CacheableClass1.a_defined_super_class_method_with_cache).to eq(3)
+      context 'with method is defined from supper class' do
+        it 'returns correct value' do
+          expect(CacheableClass1.a_defined_super_class_method(3)).to eq(3)
+        end
+
+        it 'calls Rails.cache with the expected arguments' do
+          expect(Rails.cache).to receive(:fetch).with(
+            "#{Cacheable::CacheVersion.get}:#{CacheableClass1.name}:a_defined_super_class_method:3", expires_in: cache_duration
+          )
+          CacheableClass1.a_defined_super_class_method(3)
+        end
       end
 
       describe 'arguments' do

--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -40,20 +40,20 @@ RSpec.describe Cacheable do
       Cacheable::CacheVersion.inc
 
       module CacheableInclude
-        def a_defined_module_method
-          2
+        def a_defined_module_method(x)
+          x
         end
       end
 
       module CacheableExtend
-        def a_defined_module_class_method
-          2
+        def a_defined_module_class_method(x)
+          x
         end
       end
 
       class CacheableBase
-        def self.a_defined_super_class_method
-          3
+        def self.a_defined_super_class_method(x)
+          x
         end
       end
 
@@ -66,7 +66,8 @@ RSpec.describe Cacheable do
 
         caches_method :method_1, :output, :method_2, :more_arguments, :contains?
         caches_method :with_expiry, expires_in: 5.minutes
-        caches_extended_method :a_defined_super_class_method
+        caches_method :a_defined_module_method
+        caches_class_method :a_defined_module_class_method, :a_defined_super_class_method
 
         def method_1
           1
@@ -97,9 +98,11 @@ RSpec.describe Cacheable do
         include Cacheable
 
         caches_method :method_1, :method_2, :a_class_method, :method_3
-        caches_method :method_4, :method_5, memoized: true
-        caches_method :with_expiry, expires_in: 6.minutes
-        caches_method :method_with_locale, include_locale: true
+        caches_method :method_5, memoized: true
+        caches_class_method :method_4, memoized: true
+        caches_class_method :with_expiry, expires_in: 6.minutes
+        caches_class_method :method_with_locale, include_locale: true
+        caches_class_method :a_class_method, :method_3
 
         def method_1
           1

--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -209,22 +209,25 @@ RSpec.describe Cacheable do
       it 'calls Rails.cache with the proper cache key' do
         expect(Rails.cache).to receive(:fetch).with(
           "#{Cacheable::CacheVersion.get}:#{instance_1.class.name}:#{instance_1.object_id}:more_arguments:0:1",
-          expires_in: cache_duration)
+          expires_in: cache_duration
+        )
         instance_1.more_arguments(0, 1)
       end
 
       it 'calls Rails.cache with the proper cache key with updated_at' do
         expect(Rails.cache).to receive(:fetch).with(
           "#{Cacheable::CacheVersion.get}:#{instance_1.class.name}:#{instance_1.object_id}:#{Date.today}:more_arguments:0:1",
-          expires_in: cache_duration)
-        instance_1.updated_at = Date.today  
+          expires_in: cache_duration
+        )
+        instance_1.updated_at = Date.today
         instance_1.more_arguments(0, 1)
       end
 
       it 'calls Rails.cache with the proper cache duration' do
         expect(Rails.cache).to receive(:fetch).with(
           "#{Cacheable::CacheVersion.get}:#{instance_1.class.name}:#{instance_1.object_id}:with_expiry:",
-          expires_in: 5.minutes)
+          expires_in: 5.minutes
+        )
         instance_1.with_expiry
       end
 
@@ -286,25 +289,29 @@ RSpec.describe Cacheable do
 
       it 'will cache the class method if there is an instance method with same name' do
         expect(instance_2.a_class_method).to eq(
-          "This is an instance method but the name is same as one of class's methods")
+          "This is an instance method but the name is same as one of class's methods"
+        )
       end
 
       it 'calls Rails.cache with the expected arguments' do
         expect(Rails.cache).to receive(:fetch).with(
-          "#{Cacheable::CacheVersion.get}:#{CacheableClass2.name}:a_class_method:x:y", expires_in: cache_duration)
-        CacheableClass2.a_class_method_with_cache('x', 'y')
+          "#{Cacheable::CacheVersion.get}:#{CacheableClass2.name}:a_class_method:x:y", expires_in: cache_duration
+        )
+        CacheableClass2.a_class_method('x', 'y')
       end
 
       it 'calls Rails.cache with the expected arguments with locale' do
         expect(Rails.cache).to receive(:fetch).with(
-          "#{Cacheable::CacheVersion.get}:#{CacheableClass2.name}:method_with_locale:3:1:en", expires_in: cache_duration)
-        CacheableClass2.method_with_locale_with_cache(3, 1)
+          "#{Cacheable::CacheVersion.get}:#{CacheableClass2.name}:method_with_locale:3:1:en", expires_in: cache_duration
+        )
+        CacheableClass2.method_with_locale(3, 1)
       end
 
       it 'calls Rails.cache with the provided duration' do
         expect(Rails.cache).to receive(:fetch).with(
           "#{Cacheable::CacheVersion.get}:#{CacheableClass2.name}:with_expiry:",
-          expires_in: 6.minutes)
+          expires_in: 6.minutes
+        )
         CacheableClass2.with_expiry
       end
 
@@ -347,10 +354,11 @@ RSpec.describe Cacheable do
 
       describe 'delete_cache' do
         it 'calls Rails.cache.delete' do
-          CacheableClass2.method_3(4,5)
+          CacheableClass2.method_3(4, 5)
           expect(Rails.cache).to receive(:delete).with(
-            "#{Cacheable::CacheVersion.get}:#{CacheableClass2.name}:method_3:4:5")
-          CacheableClass2.delete_method_3_cache(4,5)
+            "#{Cacheable::CacheVersion.get}:#{CacheableClass2.name}:method_3:4:5"
+          )
+          CacheableClass2.delete_method_3_cache(4, 5)
         end
       end
     end


### PR DESCRIPTION
**Purpose**
Rewrite using `prepend` instead of `alias`. `alias_method_chain` is deprecated and will be removed someday. Also need to fix the big issue. The issue is the gem doesn't work with `include instance method`, `extend class method` and `all inherited methods from super class`.

**Approach**
Rewrite using `prepend`

**Changes:**
Will not support `method_name_with_cache` and `method_name_without_cache` any more. 
Just need to call `method_name`.

Need to use two separate define functions for instance and class methods
``` 
caches_method :a_defined_method
caches_class_method :a_defined_class_method
```