### PR TITLE
Option to include_currency

### DIFF
--- a/lib/cacheable/cacheable.rb
+++ b/lib/cacheable/cacheable.rb
@@ -37,7 +37,7 @@ module Cacheable
     options = args.pop
     key_parts = [class_signature(klass), method, args]
     key_parts << I18n.locale if options.is_a?(Hash) && options[:include_locale] == true
-    key_parts << Cacheable.currency if options.is_a?(Hash) && options[:include_currency] == true
+    key_parts << Cacheable.currency if options.is_a?(Hash) && options[:include_currency] == true && Cacheable.currency
     key_parts.join(':')
   end
 

--- a/lib/cacheable/cacheable.rb
+++ b/lib/cacheable/cacheable.rb
@@ -9,6 +9,14 @@ module Cacheable
     @duration = duration
   end
 
+  def self.currency
+    @currency
+  end
+
+  def self.set_currency(currency)
+    @currency = currency
+  end
+
   self.default_cache_duration = 1.day
 
   def self.class_signature(obj)
@@ -29,7 +37,7 @@ module Cacheable
     options = args.pop
     key_parts = [class_signature(klass), method, args]
     key_parts << I18n.locale if options.is_a?(Hash) && options[:include_locale] == true
-    key_parts << cookies[:currency] || site_config[:currency] if options.is_a?(Hash) && options[:include_currency] == true
+    key_parts << Cacheable.currency if options.is_a?(Hash) && options[:include_currency] == true
     key_parts.join(':')
   end
 

--- a/lib/cacheable/cacheable.rb
+++ b/lib/cacheable/cacheable.rb
@@ -29,7 +29,7 @@ module Cacheable
     options = args.pop
     key_parts = [class_signature(klass), method, args]
     key_parts << I18n.locale if options.is_a?(Hash) && options[:include_locale] == true
-    key_parts << cookie[:currency] || site_config[:currency] if options.is_a?(Hash) && options[:include_currency] == true
+    key_parts << cookies[:currency] || site_config[:currency] if options.is_a?(Hash) && options[:include_currency] == true
     key_parts.join(':')
   end
 

--- a/lib/cacheable/cacheable.rb
+++ b/lib/cacheable/cacheable.rb
@@ -29,6 +29,7 @@ module Cacheable
     options = args.pop
     key_parts = [class_signature(klass), method, args]
     key_parts << I18n.locale if options.is_a?(Hash) && options[:include_locale] == true
+    key_parts << cookie[:currency] || site_config[:currency] if options.is_a?(Hash) && options[:include_currency] == true
     key_parts.join(':')
   end
 

--- a/lib/cacheable/cacheable.rb
+++ b/lib/cacheable/cacheable.rb
@@ -13,7 +13,7 @@ module Cacheable
     @currency
   end
 
-  def self.set_currency(currency)
+  def self.currency=(currency)
     @currency = currency
   end
 

--- a/lib/cacheable/cacheable.rb
+++ b/lib/cacheable/cacheable.rb
@@ -29,7 +29,7 @@ module Cacheable
     options = args.pop
     key_parts = [class_signature(klass), method, args]
     key_parts << I18n.locale if options.is_a?(Hash) && options[:include_locale] == true
-    key_parts << cookies[:currency] || site_config[:currency] if options.is_a?(Hash) && options[:include_currency] == true
+    key_parts << Cacheable.currency if options.is_a?(Hash) && options[:include_currency] == true
     key_parts.join(':')
   end
 

--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Cacheable do
 
       context 'given methods with memoized as default' do
         let(:instance_1) { CacheableClass1.new }
-        it { expect(subject).to receive(:fetch).once.and_return(2) }
+        it { expect(subject).to receive(:fetch).twice.and_return(2) }
         after do
           instance_1.method_1
           instance_1.method_1


### PR DESCRIPTION
Now on wego-amp, there's an issue: changing the site_code does not changes the currency accordingly. The reason is we only cache by locale, so even if site_code (hence currency) changes, it still picks up the same cache.
This PR adds the option to include currency in the cache key
Issue: https://wego.slack.com/archives/C096JH54G/p1511317570000032

Changes need to be made on wego-amp: https://github.com/wego/wego-amp/pull/254
